### PR TITLE
Sprint9 128 icons in buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,31 +365,31 @@
   <div class="container" style="text-align: center;">
 
     <wvr-button btn-class="primary" btn-size="large">
-      <wvr-text value=" Large Size Primary Button "></wvr-text>
+      <wvr-text value="Large Size Primary Button"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="secondary" btn-size="small">
-      <wvr-text value=" Small Size Secondary "></wvr-text>
+      <wvr-text value="Small Size Secondary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="success">
-      <wvr-text value=" Success "></wvr-text>
+      <wvr-text value="Success"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="danger">
-      <wvr-text value=" Danger "></wvr-text>
+      <wvr-text value="Danger"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="warning">
-      <wvr-text value=" Warning "></wvr-text>
+      <wvr-text value="Warning"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="info">
-      <wvr-text value=" Info "></wvr-text>
+      <wvr-text value="Info"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="light">
-      <wvr-text value=" Light "></wvr-text>
+      <wvr-text value="Light"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="dark">
-      <wvr-text value=" Dark "></wvr-text>
+      <wvr-text value="Dark"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="link" wvr-btn-type="button" href="www.google.com">
-      <wvr-text value=" Link "></wvr-text>
+      <wvr-text value="Link"></wvr-text>
     </wvr-button>
 
   </div>
@@ -420,7 +420,7 @@
                 text-align="center"
                 vertical-align="var(--wvr-btn-vertical-align)"
                 >
-      <wvr-text value=" Customized Button "></wvr-text>
+      <wvr-text value="Customized Button"></wvr-text>
     </wvr-button>
   </div>
 
@@ -430,25 +430,25 @@
       <wvr-text value="Outline Primary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-secondary" wvr-btn-type="button">
-      <wvr-text value="Outline Secondary "></wvr-text>
+      <wvr-text value="Outline Secondary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-success" wvr-btn-type="button">
-      <wvr-text value="Outline Success "></wvr-text>
+      <wvr-text value="Outline Success"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-danger" wvr-btn-type="button">
-      <wvr-text value="Outline Danger "></wvr-text>
+      <wvr-text value="Outline Danger"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-warning" wvr-btn-type="button">
-      <wvr-text value="Outline Warning "></wvr-text>
+      <wvr-text value="Outline Warning"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-info" wvr-btn-type="button">
-      <wvr-text value="Outline Info "></wvr-text>
+      <wvr-text value="Outline Info"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-light" wvr-btn-type="button">
-      <wvr-text value="Outline Light "></wvr-text>
+      <wvr-text value="Outline Light"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-dark" wvr-btn-type="button">
-      <wvr-text value="Outline Dark "></wvr-text>
+      <wvr-text value="Outline Dark"></wvr-text>
     </wvr-button>
   </div>
 
@@ -456,6 +456,14 @@
   <div class="container" style="text-align: center;">
     <wvr-icon set="custom" name="weaver-w"></wvr-icon>
     <wvr-icon set="custom" name="weaver-w" color="#500000" size="64px"></wvr-icon>
+    <wvr-button btn-class="primary" wvr-btn-type="button">
+      <wvr-icon set="custom" name="weaver-w" color="#500000"></wvr-icon>
+      <wvr-text value="Icon Btn"></wvr-text>
+    </wvr-button>
+    <wvr-button btn-class="info" wvr-btn-type="button">
+      <wvr-text value="Icon Btn"></wvr-text>
+      <wvr-icon set="custom" name="weaver-w" color="#500000"></wvr-icon>
+    </wvr-button>
   </div>
 
 

--- a/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.scss
@@ -1060,4 +1060,13 @@
     text-decoration: var(--wvr-btn-link-active-text-decoration);
   }
 
+  .btn {
+    ::ng-deep {
+      svg {
+        vertical-align: middle;
+        margin: 0px 0px 0px 5px;
+      }
+    }
+  }
+
 }

--- a/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.scss
@@ -1062,7 +1062,7 @@
 
   .btn {
     ::ng-deep {
-      svg {
+      wvr-icon svg {
         vertical-align: middle;
         margin: 0px 0px 0px 5px;
       }

--- a/src/index.html
+++ b/src/index.html
@@ -366,31 +366,31 @@
   <div class="container" style="text-align: center;">
 
     <wvr-button btn-class="primary" btn-size="large">
-      <wvr-text value=" Large Size Primary Button "></wvr-text>
+      <wvr-text value="Large Size Primary Button"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="secondary" btn-size="small">
-      <wvr-text value=" Small Size Secondary "></wvr-text>
+      <wvr-text value="Small Size Secondary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="success">
-      <wvr-text value=" Success "></wvr-text>
+      <wvr-text value="Success"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="danger">
-      <wvr-text value=" Danger "></wvr-text>
+      <wvr-text value="Danger"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="warning">
-      <wvr-text value=" Warning "></wvr-text>
+      <wvr-text value="Warning"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="info">
-      <wvr-text value=" Info "></wvr-text>
+      <wvr-text value="Info"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="light">
-      <wvr-text value=" Light "></wvr-text>
+      <wvr-text value="Light"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="dark">
-      <wvr-text value=" Dark "></wvr-text>
+      <wvr-text value="Dark"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="link" wvr-btn-type="button" href="www.google.com">
-      <wvr-text value=" Link "></wvr-text>
+      <wvr-text value="Link"></wvr-text>
     </wvr-button>
 
   </div>
@@ -431,25 +431,25 @@
       <wvr-text value="Outline Primary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-secondary" wvr-btn-type="button">
-      <wvr-text value="Outline Secondary "></wvr-text>
+      <wvr-text value="Outline Secondary"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-success" wvr-btn-type="button">
-      <wvr-text value="Outline Success "></wvr-text>
+      <wvr-text value="Outline Success"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-danger" wvr-btn-type="button">
-      <wvr-text value="Outline Danger "></wvr-text>
+      <wvr-text value="Outline Danger"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-warning" wvr-btn-type="button">
-      <wvr-text value="Outline Warning "></wvr-text>
+      <wvr-text value="Outline Warning"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-info" wvr-btn-type="button">
-      <wvr-text value="Outline Info "></wvr-text>
+      <wvr-text value="Outline Info"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-light" wvr-btn-type="button">
-      <wvr-text value="Outline Light "></wvr-text>
+      <wvr-text value="Outline Light"></wvr-text>
     </wvr-button>
     <wvr-button btn-class="outline-dark" wvr-btn-type="button">
-      <wvr-text value="Outline Dark "></wvr-text>
+      <wvr-text value="Outline Dark"></wvr-text>
     </wvr-button>
   </div>
 
@@ -457,6 +457,14 @@
   <div class="container" style="text-align: center;">
     <wvr-icon set="custom" name="weaver-w"></wvr-icon>
     <wvr-icon set="custom" name="weaver-w" color="#500000" size="64px"></wvr-icon>
+    <wvr-button btn-class="primary" wvr-btn-type="button">
+      <wvr-icon set="custom" name="weaver-w" color="#500000"></wvr-icon>
+      <wvr-text value="Icon Btn"></wvr-text>
+    </wvr-button>
+    <wvr-button btn-class="info" wvr-btn-type="button">
+      <wvr-text value="Icon Btn"></wvr-text>
+      <wvr-icon set="custom" name="weaver-w" color="#500000"></wvr-icon>
+    </wvr-button>
   </div>
 
 


### PR DESCRIPTION
Resolves #128 

This resolves the issue by applying styling instructions to all `wrv-icon svg` elements within buttons. There is also the addition of buttons containing icons to both the ng start and static index pages. There were extraneous spaces removed from wvr-text values on both index files as well.