### PR TITLE
Priority given to the list item context attribute followed by parents…

### DIFF
--- a/projects/wvr-elements/src/lib/wvr-list/wvr-list-item/wvr-list-item.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-list/wvr-list-item/wvr-list-item.component.ts
@@ -32,9 +32,12 @@ export class WvrListItemComponent extends WvrBaseComponent implements OnInit {
 
     const listTypeAttribute = this._parent ? this._parent.getAttribute('list-type') : undefined;
     this.listType = listTypeAttribute ? listTypeAttribute : 'unordered';
-
     const contextAttribute = this._parent ? (this._parent.getAttribute('context') as Theme) : undefined;
-    this.context = contextAttribute ? contextAttribute : undefined;
+    this.context = this.context ?
+                   this.context :
+                   contextAttribute ?
+                   contextAttribute :
+                   undefined;
   }
 
 }


### PR DESCRIPTION
Resolves #199 The list item context attr should override the visual context of the list item.