### PR TITLE
Added mobile-menu-content class for mobile-menu template

### DIFF
--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.html
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.html
@@ -11,7 +11,7 @@
       </div>
     </div>
   </nav>
-  
+
   <div class="title-row row m-0">
     <div class="container d-flex align-items-center">
       <a *ngIf="headerTitleUrl" [href]="headerTitleUrl"><span class="h1 text-white">{{headerTitle}}</span></a>
@@ -42,7 +42,7 @@
       </svg>
     </div>
   </div>
-  <div class="flex-fill align-self-stretch">
+  <div class="mobile-menu-content flex-fill align-self-stretch">
     <ng-container *ngTemplateOutlet="mobileMenuContent"></ng-container>
   </div>
 </nav>

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
@@ -71,6 +71,32 @@
     display: inline-block;
   }
 
+  .mobile-menu > div > div > wvr-nav-li > li {
+    > a {
+      white-space: nowrap;
+    }
+  }
+
+  // .mobile-menu > div.mobile-menu-content {
+  //   > div > wvr-nav-li > li > a {
+  //     white-space: nowrap;
+  //   }
+    // background: tomato;
+    // >div {
+    //   wvr-nav-li > li.nav-item {
+    //     a {
+    //       white-space: nowrap;
+    //     }
+    //     .mobile-display {
+    //       white-space: nowrap;
+    //     }
+    //     wvr-dropdown-element > .wvr-dropdown .dropdown wvr-button-element {
+    //       white-space: nowrap;
+    //     }
+    //   }
+    // }
+  // }
+
   .mobile-menu.closed {
     width: 0px;
     opacity: 0;

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
@@ -67,13 +67,19 @@
     cursor: pointer;
   }
 
-  .mobile-menu {
-    display: inline-block;
-  }
-
-  .mobile-menu > div > div > wvr-nav-li > li {
-    > a {
-      white-space: nowrap;
+  .mobile-menu-content {
+    white-space: nowrap !important;
+    ::ng-deep {
+      .section-title {
+        white-space: nowrap !important;
+      }
+      tl-nav-li > a {
+        white-space: nowrap !important;
+      }
+      wvr-dropdown-element,
+      .section-title  {
+        min-width: 200px;
+      }
     }
   }
 

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
@@ -83,26 +83,6 @@
     }
   }
 
-  // .mobile-menu > div.mobile-menu-content {
-  //   > div > wvr-nav-li > li > a {
-  //     white-space: nowrap;
-  //   }
-    // background: tomato;
-    // >div {
-    //   wvr-nav-li > li.nav-item {
-    //     a {
-    //       white-space: nowrap;
-    //     }
-    //     .mobile-display {
-    //       white-space: nowrap;
-    //     }
-    //     wvr-dropdown-element > .wvr-dropdown .dropdown wvr-button-element {
-    //       white-space: nowrap;
-    //     }
-    //   }
-    // }
-  // }
-
   .mobile-menu.closed {
     width: 0px;
     opacity: 0;

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.ts
@@ -1,6 +1,6 @@
 import { AfterContentChecked, Component, HostBinding, Injector, Input, OnInit } from '@angular/core';
 import { WvrBaseComponent } from '../shared/wvr-base.component';
-console.log("BUILD 1");
+console.log("BUILD 6");
 /**
  * Intended to appear at the top of document and provides for branding, links and page title.
  */

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.ts
@@ -1,6 +1,6 @@
 import { AfterContentChecked, Component, HostBinding, Injector, Input, OnInit } from '@angular/core';
 import { WvrBaseComponent } from '../shared/wvr-base.component';
-
+console.log("BUILD 1");
 /**
  * Intended to appear at the top of document and provides for branding, links and page title.
  */

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-  <wvr-header hidden-in-mobile="true">
+  <wvr-header>
     <wvr-nav-list top-navigation>
       <wvr-nav-li>
         <wvr-dropdown


### PR DESCRIPTION
Resolves  - The text-wrap property of the mega menu causes an undesirable flicker when expanding collapsing.