### PR TITLE
sprint12-233-footer-not-displaying-in-mobile-view

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -730,7 +730,7 @@
   <div class="container index-container">
 
     <wvre-text value="Tabs" text-decoration="underline"></wvre-text><br /><br />
-  
+
     <wvre-tabs>
       <wvre-tab tab-text="Tab One">
         <div class="jumbotron">
@@ -745,10 +745,10 @@
         </div>
       </wvre-tab>
     </wvre-tabs>
-  
+
   </div>
 
-  <wvre-footer hidden-in-mobile="true">
+  <wvre-footer>
     <wvre-nav-list aligned="CENTER">
       <wvre-nav-li>
         <wvre-text value="Action 1"></wvre-text>


### PR DESCRIPTION
Resolves #233 On safari (check firefox) mobile display does not run the position footer function at load time.