### PR TITLE
[Issue 363] Weaver Components should use an alternate mechanism to display: none when components are ready.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,10 +31,18 @@ export class AppModule {
   ngDoBootstrap(): void {
     registerCustomElements(this.injector, WVR_ELEMENTS);
     showHiddentContent(this.injector);
+
     wvrTimeout(() => {
+      const elements = document.querySelectorAll('.wvr-components-display:not(body)');
+      elements.forEach(function(element) {
+        element.classList.remove('wvr-components-display');
+      });
+
       const bodyElem = document.querySelector('body');
-      bodyElem.style.display = 'block';
-      bodyElem.classList.remove('wvr-hidden');
+      if (bodyElem) {
+        bodyElem.classList.remove('wvr-components-display');
+        bodyElem.classList.remove('wvr-hidden');
+      }
     });
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,14 +33,14 @@ export class AppModule {
     showHiddentContent(this.injector);
 
     wvrTimeout(() => {
-      const elements = document.querySelectorAll('.wvr-components-display:not(body)');
+      const elements = document.querySelectorAll('.wvr-components-loading:not(body)');
       elements.forEach(function(element) {
-        element.classList.remove('wvr-components-display');
+        element.classList.remove('wvr-components-loading');
       });
 
       const bodyElem = document.querySelector('body');
       if (bodyElem) {
-        bodyElem.classList.remove('wvr-components-display');
+        bodyElem.classList.remove('wvr-components-loading');
         bodyElem.classList.remove('wvr-hidden');
       }
     });

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,7 @@
 
 </head>
 
-<body class="wvr-components-display">
+<body class="wvr-components-loading">
 
   <wvre-header title-row-theme-variant="primary" top-nav-theme-variant="primaryNeutral" bottom-nav-theme-variant="primaryNeutral">
     <wvre-nav-list top-navigation>

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,7 @@
 
 </head>
 
-<body style="display: none;">
+<body class="wvr-components-display">
 
   <wvre-header title-row-theme-variant="primary" top-nav-theme-variant="primaryNeutral" bottom-nav-theme-variant="primaryNeutral">
     <wvre-nav-list top-navigation>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,7 +7,7 @@
   @import '../projects/wvr-elements/src/lib/shared/styles/overrides';
 }
 
-.wvr-components-display,
+.wvr-components-loading,
 .wvr-hidden {
   display: none;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,7 @@
   @import '../projects/wvr-elements/src/lib/shared/styles/overrides';
 }
 
+.wvr-components-display,
 .wvr-hidden {
   display: none;
 }


### PR DESCRIPTION
On startup, weaver will remove all `wvr-components-loading` classes.
The body element is reserved for last to ensure that the body doesn't become visible while other elements are being updated.

resolves #363 