### PR TITLE
Added path params to entry options

### DIFF
--- a/projects/wvr-elements/src/lib/core/manifest/manifest.effects.ts
+++ b/projects/wvr-elements/src/lib/core/manifest/manifest.effects.ts
@@ -42,9 +42,15 @@ export class ManifestEffects {
           return ManifestActions.queueRequest({ request });
         }
 
+        let path = entry.path;
+        request.options.pathVariables.forEach((v, k) => {
+          path = path.split(k)
+            .join(v);
+        });
+
         const method = request.method ? request.method : entry.methods[0];
         // TODO: validate method with allowed methods on manifests entry
-        const url = manifest.baseUrl + entry.path;
+        const url = manifest.baseUrl + path;
         const options = { ...entry.options, ...request.options };
         const onSuccess = request.onSuccess ? request.onSuccess : [];
         const onFailure = request.onFailure ? request.onFailure : [];

--- a/projects/wvr-elements/src/lib/core/rest/request-options.ts
+++ b/projects/wvr-elements/src/lib/core/rest/request-options.ts
@@ -4,6 +4,7 @@ export interface RequestOptions {
   headers?: { [header: string]: string | Array<string>; };
   observe?: 'body' | 'response' | 'events';
   params?: HttpParams | { [param: string]: string | Array<string>; };
+  pathVariables?: Map<string, string>;
   reportProgress?: boolean;
   responseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   withCredentials?: boolean;


### PR DESCRIPTION
Adds the `pathVariables` map to the manifest entry's options, and uses these to rebuild the URL upon request.