### PR TITLE
Issue 428: Weaver Components Memory and Performance Concerns.

### DIFF
--- a/projects/wvr-elements/src/lib/core/theme/theme.service.ts
+++ b/projects/wvr-elements/src/lib/core/theme/theme.service.ts
@@ -4,6 +4,7 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { filter } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 import { ThemeVariants } from '../../shared/theme';
 import { hexToRgb, luminance, mix, yiq } from '../../shared/utility/color.utility';
 import { WvrThemeableComponent } from '../../shared/wvr-themeable.component';
@@ -20,19 +21,25 @@ export class ThemeService {
 
   themedComponents: Map<number, WvrThemeableComponent>;
 
+  subscription: Subscription;
+
   constructor(private readonly store: Store<RootState>) {
     this.themedComponents = new Map<number, WvrThemeableComponent>();
-    this.store.pipe(
+    this.subscription = this.store.pipe(
       select(selectThemeState),
       filter(themeState => !!themeState)
     )
-      .subscribe(themeState => {
-        this.themes = themeState.themes;
-        this.currentTheme = this.themes[themeState.currentTheme];
-        this.themedComponents.forEach((themeableComponent: WvrThemeableComponent, id: number) => {
-          this.applyTheme(this.currentTheme, themeableComponent);
-        });
+    .subscribe(themeState => {
+      this.themes = themeState.themes;
+      this.currentTheme = this.themes[themeState.currentTheme];
+      this.themedComponents.forEach((themeableComponent: WvrThemeableComponent, id: number) => {
+        this.applyTheme(this.currentTheme, themeableComponent);
       });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
   registerComponent(id: number, themeableComponent: WvrThemeableComponent): void {

--- a/projects/wvr-elements/src/lib/shared/utility/template.utility.ts
+++ b/projects/wvr-elements/src/lib/shared/utility/template.utility.ts
@@ -3,6 +3,7 @@
 /* TODO: Issue #292. */
 import * as JSON5 from 'json5';
 import Handlebars from 'handlebars/dist/cjs/handlebars';
+import { Subscription } from 'rxjs';
 import { WvrDataSelect } from '../../core/data-select';
 import { WvrDataComponent } from '../wvr-data.component';
 import { wvrTimeout } from '../../shared/utility/timing.utility';
@@ -14,7 +15,7 @@ const wvrCompile = (d: {}, s: WvrDataSelect, elem: HTMLElement, projectedContent
   projectedContentElem.outerHTML = compiledContent;
 };
 
-const wvrParseProjectedContent = (component: WvrDataComponent, elem: HTMLElement): void => {
+const wvrParseProjectedContent = (component: WvrDataComponent, elem: HTMLElement, subscriptions: Array<Subscription>): void => {
   if (!component.hasWvrData()) {
     return;
   }
@@ -30,9 +31,11 @@ const wvrParseProjectedContent = (component: WvrDataComponent, elem: HTMLElement
     wvrDataSelects
       .filter((s: WvrDataSelect) => !!s.manifest && !!s.entry && !!s.as)
       .forEach((s: WvrDataSelect) => {
-        component.data[s.as].subscribe(d => {
-          wvrCompile(d, s, elem, projectedContentElem as HTMLElement);
-        });
+        subscriptions.push(
+          component.data[s.as].subscribe(d => {
+            wvrCompile(d, s, elem, projectedContentElem as HTMLElement);
+          })
+        );
       });
   });
 };

--- a/projects/wvr-elements/src/lib/shared/wvr-base.component.ts
+++ b/projects/wvr-elements/src/lib/shared/wvr-base.component.ts
@@ -146,7 +146,7 @@ export abstract class WvrBaseComponent implements AfterContentInit, OnInit, OnDe
     this.processData();
     this.initializeAnimationRegistration();
     this.themeService.registerComponent(this.id, this);
-    wvrParseProjectedContent(this, this.eRef.nativeElement);
+    wvrParseProjectedContent(this, this.eRef.nativeElement, this.subscriptions);
 
     this.isMobile = this.store.pipe(select(selectIsMobileLayout));
 


### PR DESCRIPTION
This is a quick fix for improving unsubscribe behavior.
This is not a complete fix for #428 .

This does not bother with trying to determine a good name for the subscriptions.

This re-uses the existing shared subscription array, making appropriate changes to make this possible.
A better design approach is preferred, but I consider this an acceptable quick fix.

Anywhere the shared store is not used and can be avoided, an `ngOnDestroy()` is called directly with the appropriate `.unsubscribe();` call.

These changes appear to significantly reduce the impact of the problem.
I do not believe these changes alone solve the problem.
I believe this design approach can be greatly improved upon.