### PR TITLE
Local npm via Verdaccio and SASS Migrator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ src/assets/tinymce/
 !src/assets/icons/feather/chevron-right.svg
 
 .wvr-ud/static-assets/styles.css
+
+.verdaccio

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "DOCKER_SERVER": ""
   },
   "scripts": {
+    "postinstall": "node scripts/post-install.js",
     "build": "ng build --configuration production --single-bundle --output-hashing none",
     "build:clean": "npm run clean && npm run build",
     "build:wvr-elements": "ng build --configuration production wvr-elements",
@@ -132,6 +133,7 @@
     "ts-node": "~10.2.1",
     "tslint": "~6.1.3",
     "typescript": "~4.3.5",
+    "sass-migrator": "^1.5.2",
     "verdaccio": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,18 +30,21 @@
     "build:static-docs": "npm run test:audit && npm run build:static-setup && npm run build:docs-usage && npm run build:docs-development",
     "build:static-reports": "npm run build:static-setup && npm run test:coverage",
     "build:static-production": "npm run build:static && node scripts/build-wvr-components-configuration.js defaults-ci-overrides.env",
-    "clean": "npm run clean:dist && npm run clean:static",
+    "clean": "npm run clean:dist && npm run clean:static && npm run clean:npm-local",
     "clean:dist": "rimraf dist",
     "clean:static": "rimraf static",
+    "clean:npm-local": "rimraf .verdaccio",
     "publish:docker": "node scripts/docker-push.js",
     "publish:npm": "npm run build && node scripts/build-publish.js $1",
     "publish:npm-next": "npm run publish:npm next",
+    "publish:npm-local": "npm run publish:npm next local",
     "lint": "ng lint",
     "ng": "ng",
     "start": "node scripts/build-wvr-components-style.js && node scripts/build-wvr-components-configuration.js defaults-dev-overrides.env && ng serve --port 4200",
     "start:dist": "node scripts/build-wvr-components-style.js && node scripts/build-wvr-components-configuration.js defaults-dist-overrides.env && node scripts/serve-dist.js",
     "start:static": "node scripts/build-wvr-components-style.js && node scripts/build-wvr-components-configuration.js defaults-static-overrides.env && static-server static -p 8081",
     "start:docker": "node scripts/build-wvr-components-style.js && node scripts/start-docker.js",
+    "start:npm-local": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
     "test": "npm run test:unit && npm run test:e2e",
     "test:audit": "rimraf .lighthouseci && lhci autorun --upload.target=temporary-public-storage --config=./lighthouserc.json && node scripts/build-wvr-components-lighthouse-badges.js",
     "test:e2e": "ng e2e",
@@ -128,6 +131,7 @@
     "static-server": "^2.2.1",
     "ts-node": "~10.2.1",
     "tslint": "~6.1.3",
-    "typescript": "~4.3.5"
+    "typescript": "~4.3.5",
+    "verdaccio": "^5.2.0"
   }
 }

--- a/scripts/build-publish.js
+++ b/scripts/build-publish.js
@@ -6,6 +6,7 @@ const angularCli = require('@angular/cli');
 const elementsPath = 'dist/wvr-elements';
 
 const next = process.argv[2] ? '--tag next' : '';
+const registry = process.argv[3] ? '--registry http://localhost:4873' : '';
 
 angularCli.default({
   cliArgs: ['b', '--project=wvr-elements'],
@@ -16,7 +17,7 @@ angularCli.default({
   fs.copySync('scripts', `${elementsPath}/scripts`);
   fs.copySync('.wvr-ud', `${elementsPath}/.wvr-ud`);
 
-  shell.exec(`npm publish ${elementsPath}/ ${next}`);
+  shell.exec(`npm ${registry} publish ${elementsPath}/ ${next}`);
 
   shell.exit();
 });

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const shell = require('shelljs');
+const process = require('process');
+const fs = require('fs-extra');
+
+const NM_WVR_UD_DIR = `${process.cwd()}/node_modules/`;
+
+if (fs.existsSync(NM_WVR_UD_DIR)) {
+  shell.cd(NM_WVR_UD_DIR);
+  shell.exec('sass-migrator division **/*.scss');
+  shell.exit();
+}

--- a/verdaccio-config.yaml
+++ b/verdaccio-config.yaml
@@ -1,0 +1,37 @@
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+
+# path to a directory with all packages
+storage: .verdaccio/storage
+# path to a directory with plugins to include
+plugins: .verdaccio/plugins
+
+web:
+  title: Verdaccio - Weaver Components
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@wvr/*':
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '**':
+    access: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+server:
+  keepAliveTimeout: 60
+
+middlewares:
+  audit:
+    enabled: true
+
+logs: { type: stdout, format: pretty, level: http }


### PR DESCRIPTION
Introduce the Build System Improvements.

Utilize the SASS Migrator.
Utilize Verdaccio.

Verdaccio is installed locally to the project and should be run within the project as a service.

When running, the service is started at: http://localhost:4873/.

This adds the following new commands:
- `clean:npm-local`: clean the verdaccio repository.
- `publish:npm-local`: publish to the local repository (which must already be running).
- `start:npm-local`: start the local repository (runs in the foreground).

This updates the following commands:
- `npm run clean`: updated to also clean the verdaccio repository.
- `publish:npm`: the build script `scripts/build-publish.js` is updated to support a third argument to designate using the local registry.

resolves #469 