### PR TITLE
1.x sprint23 staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.12.1] - 11-17-21
+### Resolves
+
+- The mobile menu slide out tray continues to allow links to be clicked on when closed. by @kaladay in (#475)
+- Require ng-inline-svg 13.0.0, 13.0.1 currently breaks build. by @kaladay in (#485)
+
 ## [1.12.0] - 06-04-21
 ### Resolves
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "css-element-queries": "^1.2.3",
     "handlebars": "^4.7.7",
     "json5": "^2.2.0",
-    "ng-inline-svg": "^13.0.0",
+    "ng-inline-svg": "13.0.0",
     "rxjs": "~6.6.7",
     "tinymce": "^5.8.1",
     "tslib": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/TAMULib/weaver-components.git"
   },
-  "version": "1.12.0",
+  "version": "1.12.1-rc.1",
   "private": false,
   "license": "MIT",
   "config": {

--- a/projects/wvr-elements/package.json
+++ b/projects/wvr-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/elements",
-  "version": "1.12.0",
+  "version": "1.12.1-rc.1",
   "description": "Collection of angular components for Weaver's Custom Web Component UI",
   "author": "Texas A&M University Libraries",
   "private": false,

--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
@@ -70,8 +70,6 @@
   }
 
   @media (max-width: 992px) {
-
-
     .mobile-menu-button {
       display: block;
     }
@@ -82,13 +80,16 @@
 
     .mobile-menu-content {
       white-space: nowrap !important;
+
       ::ng-deep {
         .section-title {
           white-space: nowrap !important;
         }
+
         tl-nav-li > a {
           white-space: nowrap !important;
         }
+
         wvr-dropdown-component,
         .section-title  {
           min-width: 200px;
@@ -99,6 +100,7 @@
     .mobile-menu.closed {
       width: 0px;
       opacity: 0;
+      overflow: hidden;
     }
 
     .mobile-menu-header {
@@ -108,19 +110,21 @@
       color: #fff;
       width: 100%;
       padding: 12px 10px;
+
       .mobile-menu-close:hover {
         cursor: pointer;
       }
+
       li {
         font-weight: lighter;
         min-width: auto;
         border-bottom: none;
       }
+
       li:hover {
         background: transparent;
       }
     }
-
   }
 
 


### PR DESCRIPTION
* The mobile menu slide out tray continues to allow links to be clicked on when closed. by @kaladay in https://github.com/TAMULib/weaver-components/pull/475
* Require ng-inline-svg 13.0.0, 13.0.1 currently breaks build. by @kaladay in https://github.com/TAMULib/weaver-components/pull/485