### PR TITLE
Issue 461: Avoid replaceChild() and restructure projection function.

### DIFF
--- a/projects/wvr-elements/src/lib/shared/utility/bootstrap.utility.ts
+++ b/projects/wvr-elements/src/lib/shared/utility/bootstrap.utility.ts
@@ -59,6 +59,7 @@ const lazyLoadWeaverElement = (element: HTMLElement, selectors: Array<string>): 
   if (selectors.indexOf(element.parentNode.nodeName) >= 0) {
     return false;
   }
+
   if (element.parentNode.nodeName === 'BODY') {
     return true;
   }
@@ -85,7 +86,7 @@ const registerWeaverElements = (injector: Injector, wvrElements: Array<WvrElemen
             div.setAttribute('element', wvrElement.selector);
             const template = document.createElement('template');
             div.appendChild(template);
-            element.parentNode.replaceChild(div, element);
+            element.insertAdjacentElement('beforebegin', div);
             template.content.appendChild(element);
           }
         });
@@ -106,8 +107,9 @@ const registerWeaverElements = (injector: Injector, wvrElements: Array<WvrElemen
       // when wrapped element enters view port, unwrap it and remove from observer
       if (entry.isIntersecting) {
         observer.unobserve(entry.target);
-        const clone = (entry.target.childNodes[0] as HTMLTemplateElement).content.cloneNode(true);
-        entry.target.parentNode.replaceChild(clone.childNodes[0], entry.target);
+        const child = (entry.target.childNodes[0] as HTMLTemplateElement).content.childNodes[0];
+        entry.target.insertAdjacentElement('beforebegin', child as Element);
+        entry.target.parentNode.removeChild(entry.target);
       }
     });
   }, {

--- a/projects/wvr-elements/src/lib/shared/utility/projection.utility.ts
+++ b/projects/wvr-elements/src/lib/shared/utility/projection.utility.ts
@@ -13,19 +13,22 @@ const projectSourceContent = (elementRef: ElementRef, sourceElementRef: ElementR
 const project = (element: Element, sourceElementRef: ElementRef, templateSelector: string): void => {
   const templates: Array<HTMLTemplateElement> = Array.from(sourceElementRef.nativeElement.querySelectorAll(templateSelector));
   if (!!element) {
-    templates.forEach((template: HTMLTemplateElement) => {
-      const clone: Node = template.children.length === 0 && template.content.children.length > 0
-        ? template.content.cloneNode(true)
-        : template;
-      Array.from((clone as Element).children)
-        .forEach((elem: Element) => {
-          element.appendChild(elem);
-        });
-    });
-  }
-  // hide target element if nothing to project
-  if (!!element && !templates.length) {
-    (element as HTMLElement).hidden = true;
+    if (templates.length) {
+      templates.forEach((template: HTMLTemplateElement) => {
+        const clone: Node = template.children.length === 0 && template.content.children.length > 0
+          ? template.content.cloneNode(true)
+          : template;
+
+        Array.from((clone as Node).childNodes)
+          .forEach((child: Node) => {
+            element.appendChild(child);
+          });
+      });
+    }
+    else {
+      // hide target element if nothing to project
+      (element as HTMLElement).hidden = true;
+    }
   }
 };
 


### PR DESCRIPTION
Investigation revealed several areas of performance concerns.
This addresses only one of these.

One of the problems is the observation that the destructors are being called on load!
(such as `beforeunload()`).

This is observed when creating a large number of `wvre-text` or `wvre-card` (such as ~8000 of them).

The `replaceChild()` functions seem to be the culprit.
They apparently remove the element from the DOM, triggering the cleanup events.

It turns out that one can use `appendChild()` which is supposed to guarantee a Node only exists once on the DOM.
As a result, it performs a "move" operation, which does not result in a trigger of the cleanup events.
By utilizing `insertAdjacentElement()`, the div can be prepended before the element on the DOM.
This gives a location on the DOM that matches where the element would be before calling the `appendChild()`.
Then, when the `appendChild()` is performed, it can be detected that element is already on the DOM and it effectively moves the element into the template element.
No removals are performed and therefore there is nothing to trigger the cleanup events.

There are other locations where cleanup events are fired and need investigation.
This just handles the following cases:

  In bootstrap.utility.ts, ~line 85, the `replaceChild()` can be safely swapped out with `insertAdjacentElement()` and have the desired behavior.

  In bootstrap.utility.ts, ~line 106, the same approach as above is performed except that entry.target ends up dangling and needs to be removed.
  I am not 100% certain on this `removeChild()` call used here and so if there is a regressions I would expect this to be the spot.
  This also avoids cloning, which may or may not be a problem.

This seems to have a side-effect of fixing a bug where information is missing from the DOM.
This can be seen by looking at the example weaver build, scrolling down to the bottom, and looking at the color example boxes.
With this change, those boxes now have the hex digits representing the colors.

Restructure the projection call.
The `templates.length` is used a lot of times and the logic could be improved to reduce the number of checks.
This is likely a very insignificant performance increase, but at scale it may have slight improvements.
This mostly makes the logic easier to read.
It would be ideal if there was a way to mass append a set of elements to avoid having to do a loop over this.
Such a change might improve performance as it would, in theory, allow the browser to make better decisions on redrawing and event handling.

This does not fully resolves #461 there are more, bigger, performance problems.