### PR TITLE
[Issue 249] Directory UI - bottom-nav items (left most) is seen to have shifted left.

### DIFF
--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
@@ -2,7 +2,7 @@
 @import "../../shared/styles/variables";
 
 :host {
-  
+
   @extend .variables;
 
   --wvr-nav-li-cursor: pointer;
@@ -19,7 +19,6 @@
 a.nav-link,
 li.nav-item {
   height: var(--wvr-nav-li-height);
-  min-width: var(--wvr-nav-li-width);
   cursor: var(--wvr-nav-li-cursor);
   ::ng-deep wvre-dropdown {
     display: flex;
@@ -29,7 +28,7 @@ li.nav-item {
     justify-content: center;
 
     [ngbdropdown],
-    [ngdropdownanchor], 
+    [ngdropdownanchor],
     wvre-dropdown-btn,
     .wvr-dropdown {
       width: 100%;
@@ -48,6 +47,10 @@ a.nav-link {
   color: var(--wvr-nav-link-color);
   font-size: var(--wvr-nav-link-font-size);
   font-weight: var(--wvr-nav-link-font-weight);
+}
+
+li.nav-item {
+  min-width: var(--wvr-nav-li-width);
 }
 
 li.nav-item:hover {


### PR DESCRIPTION
The min-width is being applied to the text as well.
This forces the text to have a width that it does not actually span across.
This results in it appearing shifted to the left.

Only apply the min-width to the containing block rather than both the containing block and the text.