### PR TITLE
Require ng-inline-svg 13.0.0, 13.0.1 currently breaks build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "css-element-queries": "^1.2.3",
     "handlebars": "^4.7.7",
     "json5": "^2.2.0",
-    "ng-inline-svg": "^13.0.0",
+    "ng-inline-svg": "13.0.0",
     "rxjs": "~6.6.7",
     "tinymce": "^5.8.1",
     "tslib": "^2.2.0",


### PR DESCRIPTION
The build fails with this error:
```
Error during template compile of 'WvrCoreModule'
Function calls are not supported in decorators but 'InlineSVGModule' was called.
```

This fix will likely need to be reverted as soon as the project fixes its problems, or not if we have migrated fully to 2.x by then.