### PR TITLE
Change tl nav list and weaver nav list to use divs with roles.

### DIFF
--- a/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-header/wvr-header.component.scss
@@ -35,7 +35,7 @@
       transition: transform 0.3s;
       z-index: 3;
     }
-    
+
     .skip-to-content-link:focus {
       transform: translateY(0%);
     }
@@ -62,9 +62,9 @@
     .top-nav-wrapper {
       ::ng-deep {
         wvre-nav-list[top-navigation]
-        > ul
+        > [role="list"]
         > wvre-nav-li
-        > li
+        > [role=listitem]
         > wvre-dropdown
         > .wvr-dropdown
         > .dropdown
@@ -139,13 +139,13 @@
         cursor: pointer;
       }
 
-      li {
+      [role=listitem] {
         font-weight: lighter;
         min-width: auto;
         border-bottom: none;
       }
 
-      li:hover {
+      [role=listitem]:hover {
         background: transparent;
       }
     }

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.html
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.html
@@ -1,12 +1,12 @@
-<li *ngIf="href" class="nav-item d-flex align-items-center justify-content-center">
+<div *ngIf="href" class="nav-item d-flex align-items-center justify-content-center" role="listitem">
   <a class="nav-link" [href]="href">
     <ng-container *ngTemplateOutlet="contentProjection"></ng-container>
   </a>
-</li>
+</div>
 
-<li *ngIf="!href" class="nav-item d-flex align-items-center justify-content-center">
+<div *ngIf="!href" class="nav-item d-flex align-items-center justify-content-center" role="listitem">
   <ng-container *ngTemplateOutlet="contentProjection"></ng-container>
-</li>
+</div>
 
 <ng-template #contentProjection>
   <ng-content></ng-content>

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
@@ -17,7 +17,7 @@
 }
 
 a.nav-link,
-li.nav-item {
+[role=listitem].nav-item {
   height: var(--wvr-nav-li-height);
   cursor: var(--wvr-nav-li-cursor);
   ::ng-deep wvre-dropdown {
@@ -49,11 +49,11 @@ a.nav-link {
   font-weight: var(--wvr-nav-link-font-weight);
 }
 
-li.nav-item {
+[role=listitem].nav-item {
   min-width: var(--wvr-nav-li-width);
 }
 
-li.nav-item:hover {
+[role=listitem].nav-item:hover {
   background: var(--wvr-nav-link-background-hover);
   text-decoration: var(--wvr-nav-link-text-decoration-hover);
   a.nav-link {

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.scss
@@ -1,6 +1,21 @@
 @import "../../shared/styles/wvr-variables.scss";
 @import "../../shared/styles/variables";
 
+:host {
+
+  @extend .variables;
+
+  --wvr-nav-li-cursor: pointer;
+  --wvr-nav-li-height: 100%;
+  --wvr-nav-li-width: 140px;
+  --wvr-nav-link-background-hover: var(--wvr-primary);
+  --wvr-nav-link-color-hover: var(--wvr-dark);
+  --wvr-nav-link-color: var(--wvr-blue);
+  --wvr-nav-link-font-size: inherit;
+  --wvr-nav-link-font-weight: inherit;
+  --wvr-nav-link-text-decoration-hover: none;
+}
+
 a.nav-link,
 li.nav-item {
   height: var(--wvr-nav-li-height);

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-li/wvr-nav-li.component.ts
@@ -46,15 +46,4 @@ export class WvrNavLiComponent extends WvrBaseComponent {
     super(injector);
   }
 
-  ngAfterViewInit(): void {
-    const list = this.eRef.nativeElement.parentNode;
-
-    Array.from(this.eRef.nativeElement.children)
-      .forEach((elem: any) => {
-        list.appendChild(elem);
-      });
-
-    list.parentNode.appendChild(this.eRef.nativeElement);
-  }
-
 }

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.html
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.html
@@ -1,3 +1,3 @@
-<ul #animationRoot class="navbar-nav flex-wrap" [ngClass]="{ 'flex-row': vertical==='false', 'justify-content-end': aligned === 'RIGHT', 'justify-content-center': aligned === 'CENTER' }" nav-list-items>
+<div #animationRoot class="navbar-nav flex-wrap" [ngClass]="{ 'flex-row': vertical==='false', 'justify-content-end': aligned === 'RIGHT', 'justify-content-center': aligned === 'CENTER' }" role="list" nav-list-items>
   <ng-content select="template[nav-list-items]"></ng-content>
-</ul>
+</div>

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.scss
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.scss
@@ -2,20 +2,10 @@
 @import "../shared/styles/variables";
 
 :host {
-
+  
   @extend .variables;
 
   --wvr-nav-list-height: 100%;
-
-  --wvr-nav-li-cursor: pointer;
-  --wvr-nav-li-height: inherit;
-  --wvr-nav-li-width: 140px;
-  --wvr-nav-link-background-hover: var(--wvr-primary);
-  --wvr-nav-link-color-hover: var(--wvr-dark);
-  --wvr-nav-link-color: var(--wvr-blue);
-  --wvr-nav-link-font-size: inherit;
-  --wvr-nav-link-font-weight: inherit;
-  --wvr-nav-link-text-decoration-hover: none;
 }
 
 .navbar-nav {

--- a/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-nav-list/wvr-nav-list.component.ts
@@ -47,7 +47,7 @@ export class WvrNavListComponent extends WvrBaseComponent implements AfterViewIn
   }
 
   private project(): void {
-    projectContent(this.eRef, 'template[nav-list-items]', 'ul[nav-list-items]');
+    projectContent(this.eRef, 'template[nav-list-items]', 'div[nav-list-items]');
   }
 
 }


### PR DESCRIPTION
This is an alternative approach to hoisting out the list.

This has the least breakage when it comes to structural changes and CSS.

This uses roles to ensure accessibility compliance.

Anything depending on this for the nav list should change CSS (or similar) references of `ul` into `[role=list]` and `li` into `[role=listitem]`. Only change the `li` that are within the nav list.

resolves #490 
reverts #492