### PR TITLE
Fix bad error handling and reporting wvr-button.

### DIFF
--- a/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.ts
@@ -180,10 +180,7 @@ export class WvrButtonComponent extends WvrBaseComponent implements AfterViewIni
   // tslint:disable-next-line:prefer-function-over-method
   private parseActionNameAndType(nameAndType: string): any {
     const parts = nameAndType.split('.');
-    let valid = true;
-
-    valid = parts.length === 2;
-    if (!valid) {
+    if (parts.length !== 2) {
       console.warn(`'${nameAndType}' is not a valid value for 'dispatch-action'. Must in form '[ActionType].[ActionName]'`);
 
       return;
@@ -191,30 +188,24 @@ export class WvrButtonComponent extends WvrBaseComponent implements AfterViewIni
 
     const registeredActions = this.actionRegistry.getActions(parts[0]);
 
-    if (!registeredActions || !parts[1] || !registeredActions[parts[1]]) {
-      console.warn('something went wrong parsing the action input.');
+    if (!registeredActions) {
+      console.warn(`No registered actions were found for '${nameAndType}'.`);
 
       return;
     }
 
-    if (registeredActions && registeredActions[parts[0]]) {
-      valid = !!registeredActions;
-      if (!valid) {
-        const types = Object.keys(registeredActions)
-          .join(',');
-        console.warn(`'${parts[0]}' is not a known action type. (${types})`);
-      }
+    if (!parts[0] || !registeredActions[parts[0]]) {
+      const types = Object.keys(registeredActions)
+        .join(',');
+      console.warn(`'${parts[0]}' is not a known action type (${types}).`);
 
       return;
     }
 
-    if (registeredActions && registeredActions[parts[0]]) {
-      valid = !!registeredActions[parts[1]];
-      if (!valid) {
-        const actions = Object.keys(registeredActions[parts[0]])
-          .join(',');
-        console.warn(`'${parts[1]}' is not a known action of ${parts[0]}. (${actions})`);
-      }
+    if (!parts[1] || !registeredActions[parts[1]]) {
+      const actions = Object.keys(registeredActions[parts[0]])
+        .join(',');
+      console.warn(`'${parts[1]}' is not a known action of ${parts[0]} (${actions}).`);
 
       return;
     }

--- a/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.ts
+++ b/projects/wvr-elements/src/lib/wvr-button/wvr-button.component.ts
@@ -194,16 +194,8 @@ export class WvrButtonComponent extends WvrBaseComponent implements AfterViewIni
       return;
     }
 
-    if (!parts[0] || !registeredActions[parts[0]]) {
-      const types = Object.keys(registeredActions)
-        .join(',');
-      console.warn(`'${parts[0]}' is not a known action type (${types}).`);
-
-      return;
-    }
-
     if (!parts[1] || !registeredActions[parts[1]]) {
-      const actions = Object.keys(registeredActions[parts[0]])
+      const actions = Object.keys(registeredActions)
         .join(',');
       console.warn(`'${parts[1]}' is not a known action of ${parts[0]} (${actions}).`);
 


### PR DESCRIPTION
There is no reason to initialize valid and then immediately overwrite it. The variable is also unnecessary.

The initial check that prints the warning "something went wrong parsing the action input." prevents all other checks from happening. These other checks provide more detailed error reporting. Simplify this check and change the error message to only report a warning when no registered actions were found.

Remove useless and redundant checks.
Add additional checks for when parts are empty.
Many of the more detailed checks are pointless.

One of the entire if blocks appears bogus.
The `parts[0]` is used to get the registered actions.
This should not be a part of its own actions.

Fix grammar in error messages.

With this change, more useful error messages appear.
Examples:
```
No registered actions were found for 'Store.Action'.
```

Rather than this:
```
something went wrong parsing the action input.
```