### PR TITLE
Fixed tabs to no longer need a wrapping div to display content

### DIFF
--- a/projects/wvr-elements/src/lib/shared/utility/projection.utility.ts
+++ b/projects/wvr-elements/src/lib/shared/utility/projection.utility.ts
@@ -39,11 +39,7 @@ const preserveContent = (elementRef: ElementRef, templateSelector: string, targe
     Array.from(element.children)
       .filter((elem: Element) => elem.nodeName !== 'TEMPLATE')
       .forEach((elem: Element) => {
-        if (template.children.length) {
-          template.replaceChild(elem, template.children[0]);
-        } else {
-          template.appendChild(elem);
-        }
+        template.appendChild(elem);
       });
   }
 };


### PR DESCRIPTION
You no longer need a wrapping `<div>` tag to display content inside a tab.