### PR TITLE
Locked the node version to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG NPM_REGISTRY=upstream
 ARG NODE_ENV=development
 
 # Node stage.
-FROM node:lts-slim as build
+FROM node:16-slim as build
 ARG USER_ID
 ARG USER_NAME
 ARG SOURCE_DIR


### PR DESCRIPTION
This addresses the build error while running `npm run build:docker` by locking the node version to 16.