### PR TITLE
Fix dependency related build problems by downgrading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [2.0.5] - 12-02-22
+## [2.0.5-rc.2] - 09-13-24
+### Resolves
+
+- Downgrading Angular dependencies to 12.2.16 to fix npm build.
+- Added `"cheerio": "1.0.0-rc.10"` to fix npm build.
+- Added `"typescript": ">=4.2.3 <4.4"` to fix npm build.
+- Added `"whatwg-mimetype": "^3.0.0"` to fix npm build.
+
+## [2.0.5-rc.1] - 12-02-22
 ### Resolves
 
 - WYSIWYG save is not working. (#516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Resolves
 
 - Downgrading Angular dependencies to 12.2.16 to fix npm build.
-- Added `"cheerio": "1.0.0-rc.10"` to fix npm build.
+- Added `"cheerio": "1.0.0-rc.10"` to resolve issues with the compodocs command not running correctly.
 - Added `"typescript": ">=4.2.3 <4.4"` to fix npm build.
 - Added `"whatwg-mimetype": "^3.0.0"` to fix npm build.
 

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
     "test:ci": "npm run test:audit && npm run test:coverage"
   },
   "dependencies": {
-    "@angular/animations": "12.2.16",
-    "@angular/elements": "12.2.16",
-    "@angular/forms": "12.2.16",
-    "@angular/localize": "12.2.16",
-    "@angular/platform-browser-dynamic": "12.2.16",
+    "@angular/animations": "12.2.17",
+    "@angular/elements": "12.2.17",
+    "@angular/forms": "12.2.17",
+    "@angular/localize": "12.2.17",
+    "@angular/platform-browser-dynamic": "12.2.17",
     "@ng-bootstrap/ng-bootstrap": "10.0.0",
     "@ngrx/effects": "12.5.1",
     "@ngrx/entity": "12.5.1",
@@ -78,10 +78,10 @@
     "tinymce": "6.2.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "12.2.16",
+    "@angular-devkit/build-angular": "12.2.17",
     "@angular-eslint/eslint-plugin": "14.1.2",
     "@angular-eslint/eslint-plugin-template": "14.1.2",
-    "@angular/cli": "12.2.16",
+    "@angular/cli": "12.2.17",
     "@compodoc/compodoc": "1.1.19",
     "@lhci/cli": "0.9.0",
     "@ngrx/schematics": "12.5.1",
@@ -126,14 +126,19 @@
     "zone.js": "0.11.8"
   },
   "overrides": {
-    "@angular/compiler": "12.2.16",
-    "@angular/core": "12.2.16",
+    "@angular/compiler": "12.2.17",
+    "@angular/compiler-cli": "12.2.17",
+    "@angular/core": "12.2.17",
     "@types/eslint": "6.8.1",
+    "@types/node": "18.11.10",
+    "cheerio": "1.0.0-rc.10",
     "chokidar": "3.5.3",
     "fs-extra": "10.1.0",
     "glob": "7.2.3",
     "latest-version": "7.0.0",
     "selfsigned": "2.1.1",
-    "tslib": "2.4.0"
+    "tslib": "2.4.0",
+    "typescript": ">=4.2.3 <4.4",
+    "whatwg-mimetype": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/TAMULib/weaver-components.git"
   },
-  "version": "2.0.5-rc.1",
+  "version": "2.0.5-rc.2",
   "private": false,
   "license": "MIT",
   "engines": {

--- a/projects/wvr-elements/package.json
+++ b/projects/wvr-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/elements",
-  "version": "2.0.5-rc.1",
+  "version": "2.0.5-rc.2",
   "description": "Collection of angular components for Weaver's Custom Web Component UI",
   "author": "Texas A&M University Libraries",
   "private": false,

--- a/projects/wvr-elements/package.json
+++ b/projects/wvr-elements/package.json
@@ -27,7 +27,7 @@
     "tslib": "2.4.0"
   },
   "peerDependencies": {
-    "@angular/common": "12.2.16",
+    "@angular/common": "12.2.17",
     "handlebars": "4.7.7"
   }
 }


### PR DESCRIPTION
I happened to have a 2 year old package lock file. Compare and copy and paste several of the versions and problematic packages. This could use further review to get the latest but still working versions. For now, this is good enough to get things compiling.

The `12.2.16` versions of angular happened to be being pulled down by recent installs but the older package lock file shows `12.2.17`. Explicitly set the `12.2.17` in all angular cases.

Several dependencies have warnings like these:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'cheerio@1.0.0',
npm WARN EBADENGINE   required: { node: '>=18.17' },
npm WARN EBADENGINE   current: { node: 'v16.18.1', npm: '8.19.2' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'undici@6.19.8',
npm WARN EBADENGINE   required: { node: '>=18.17' },
npm WARN EBADENGINE   current: { node: 'v16.18.1', npm: '8.19.2' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'whatwg-mimetype@4.0.0',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.18.1', npm: '8.19.2' }
npm WARN EBADENGINE }
```
Downgrade the dependencies to known versions that do build.

I explicitly set the `typescript` version to `>=4.2.3 <4.4` based on some of the contents of the 2 year old package lock file. I do not know what is ideal here for the version numbers but this is good enough for now.

This also requires using Node v16 in user-space to build.